### PR TITLE
Add language selection for profile fields acquisition

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -37,6 +37,10 @@ exports.parse = function(json) {
     });
   }
 
+  if (json.city) {
+    profile.city = json.city.title;
+  }
+
   var bdate = /^(\d+)\.(\d+)\.(\d+)$/.exec(json.bdate);
   if (bdate) {
     var year = bdate[3]

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -59,7 +59,7 @@ function Strategy(options, verify) {
   this.name = 'vkontakte';
   this._profileURL = options.profileURL || 'https://api.vk.com/method/users.get';
   this._profileFields = options.profileFields || [];
-  this._apiVersion = options.apiVersion || '5.0';
+  this._apiVersion = options.apiVersion || '5.8'; // least required for getting city value
 }
 
 /**
@@ -130,6 +130,7 @@ Strategy.prototype.authorizationParams = function (options) {
  *   - `name.givenName`   the user's first name
  *   - `gender`           the user's gender: `male` or `female`
  *   - `photos`           array of `{ value: 'url' }`
+ *   - `city`             the user's city (if requested by specifying it in profileFields setting)
  *
  * @param {String} accessToken
  * @param {Function} done

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -53,6 +53,7 @@ function Strategy(options, verify) {
   options.tokenURL = options.tokenURL || 'https://oauth.vk.com/access_token';
   options.scopeSeparator = options.scopeSeparator || ',';
   options.passReqToCallback = false;
+  this.lang = options.lang || 'en';
 
   OAuth2Strategy.call(this, options, verifyWrapper(options, verify));
   this.name = 'vkontakte';
@@ -151,6 +152,8 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   });
 
   url += '?fields=' + fields.join(',') + '&v='+this._apiVersion + '&https=1';
+
+  if (this.lang) url += '&lang=' + this.lang;
 
   this._oauth2.getProtectedResource(url, accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -54,9 +54,11 @@ function Strategy(options, verify) {
   options.scopeSeparator = options.scopeSeparator || ',';
   options.passReqToCallback = false;
   this.lang = options.lang || 'en';
+  this.photoSize = options.photoSize || 200;
   
   // since options.lang have nothing to do with OAuth2Strategy
   delete options.lang;
+  delete options.photoSize;
 
   OAuth2Strategy.call(this, options, verifyWrapper(options, verify));
   this.name = 'vkontakte';
@@ -148,7 +150,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   , 'last_name'
   , 'screen_name'
   , 'sex'
-  , 'photo'
+  , 'photo_' + this.photoSize,
   ];
 
   this._profileFields.forEach(function(f) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-vkontakte",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "VK.com authentication strategy for Passport.",
   "author": {
     "name": "Jared Hanson",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-vkontakte",
-  "version": "0.3.5",
+  "version": "0.3.2",
   "description": "VK.com authentication strategy for Passport.",
   "author": {
     "name": "Jared Hanson",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-vkontakte",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "VK.com authentication strategy for Passport.",
   "author": {
     "name": "Jared Hanson",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-vkontakte",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "VK.com authentication strategy for Passport.",
   "author": {
     "name": "Jared Hanson",


### PR DESCRIPTION
By default, passport-vkontakte returns English name when authenticating. This change provides a way to change this behaviour.