### PR TITLE
feat: pass req on 6 arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,26 @@ passport.use(new VKontakteStrategy(
 ));
 ```
 
+#### Get req
+
+To get `req` into the handler, just add it as the first parameter
+
+> Other strategies pass the `passReqToCallback: true` property to `Strategy` options.
+> But here it is enough to add the first argument `req`
+
+For example, the first parameter will contain the req object:
+
+```javascript
+passport.use(new VKontakteStrategy(
+  {
+    // clientID: ..., clientSecret: ..., callbackURL: ...,
+  },
+  function myVerifyCallbackFn(req, accessToken, refreshToken, params, profile, done) {
+    // Your code
+  }
+));
+```
+
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,12 @@ passport.use(new VKontakteStrategy(
 
 #### Get req
 
-To get `req` into the handler, just add it as the first parameter
+To get `req` into the handler, just add it as the first argument
 
 > Other strategies pass the `passReqToCallback: true` property to `Strategy` options.
 > But here it is enough to add the first argument `req`
 
-For example, the first parameter will contain the req object:
+For example, the first argument will contain the req object:
 
 ```javascript
 passport.use(new VKontakteStrategy(

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -87,7 +87,7 @@ function verifyWrapper(options, verify) {
     var arity = verify.length;
     if (arity == 6) {
       verify(req, accessToken, refreshToken, params, profile, verified);
-    } if (arity == 5) {
+    } else if (arity == 5) {
       verify(accessToken, refreshToken, params, profile, verified);
     }
     else if (arity == 4) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -87,7 +87,8 @@ function verifyWrapper(options, verify) {
     var arity = verify.length;
     if (arity == 6) {
       verify(req, accessToken, refreshToken, params, profile, verified);
-    } else if (arity == 5) {
+    }
+    else if (arity == 5) {
       verify(accessToken, refreshToken, params, profile, verified);
     }
     else if (arity == 4) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -52,7 +52,7 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://oauth.vk.com/authorize';
   options.tokenURL = options.tokenURL || 'https://oauth.vk.com/access_token';
   options.scopeSeparator = options.scopeSeparator || ',';
-  options.passReqToCallback = false;
+  options.passReqToCallback = true;
   this.lang = options.lang || 'en';
   this.photoSize = options.photoSize || 200;
 
@@ -78,14 +78,16 @@ function Strategy(options, verify) {
  */
 function verifyWrapper(options, verify) {
 
-  return function passportVerify(accessToken, refreshToken, params, profile, verified) {
+  return function passportVerify(req, accessToken, refreshToken, params, profile, verified) {
 
     if (params && params.email) {
       profile.emails = [{value: params.email}];
     }
 
     var arity = verify.length;
-    if (arity == 5) {
+    if (arity == 6) {
+      verify(req, accessToken, refreshToken, params, profile, verified);
+    } if (arity == 5) {
       verify(accessToken, refreshToken, params, profile, verified);
     }
     else if (arity == 4) {


### PR DESCRIPTION
Adds `req` without breaking backward compatibility. A lot of cases when a `req` is needed in a handler